### PR TITLE
Fix/outdoors content sample

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 docker build ./tools --tag=mighty-indexer
-docker run --rm -it --network mqsnet mighty-indexer:latest ./index.sh $*
+docker run --rm -v $(pwd)/outdoors_posts.tar.gz:/outdoors_posts.tar.gz:ro -it --network mqsnet mighty-indexer:latest ./index.sh $*


### PR DESCRIPTION
Hi @binarymax,

I came across your project on the Relevance & Matching Tech Slack channel and found it very interesting. I attempted to explore your outdoors example as described in the README.md, but unfortunately, I encountered some issues. Here's what I discovered:

- The outdoors_posts data is not available in the mighty-indexer during indexing.
- The creation of the qdrant collection in the load.js file did not function correctly.
- There were some problems with the transformation of vectors into a format suitable for indexing the points into qdrant. 

In this pull request, I have made efforts to address these issues to the best of my abilities. The changes I've implemented should restore the example to its intended functionality, allowing users to test your embeddings effectively.